### PR TITLE
Add Docker support for MineLink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use golang:1.20 as the base image
+FROM golang:1.20
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the project files into the container
+COPY . .
+
+# Build the Go application
+RUN go build -o minelink
+
+# Set the entrypoint
+ENTRYPOINT ["./minelink"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,46 @@ To run the proxy, follow these steps:
    ./minelink
    ```
 
+## Running the Proxy with Docker
+To build and run the proxy using Docker, follow these steps:
+1. Clone the repository:
+   ```
+   git clone https://github.com/waushop/minelink.git
+   ```
+2. Change to the project directory:
+   ```
+   cd minelink
+   ```
+3. Build the Docker image:
+   ```
+   docker build -t minelink .
+   ```
+4. Run the Docker container:
+   ```
+   docker run -e SERVER_ADDRESS="your_server_address:19132" -e PROXY_PORT="19133" -e BROADCAST_IP="255.255.255.255:19132" -p 19133:19133 minelink
+   ```
+
+## Running the Proxy with Docker Compose
+To build and run the proxy using Docker Compose, follow these steps:
+1. Clone the repository:
+   ```
+   git clone https://github.com/waushop/minelink.git
+   ```
+2. Change to the project directory:
+   ```
+   cd minelink
+   ```
+3. Create a `.env` file with the following content:
+   ```
+   SERVER_ADDRESS=your_server_address:19132
+   PROXY_PORT=19133
+   BROADCAST_IP=255.255.255.255:19132
+   ```
+4. Start the service using Docker Compose:
+   ```
+   docker-compose up --build
+   ```
+
 ## Contributing
 We welcome contributions to the project! If you would like to contribute, please follow these steps:
 1. Fork the repository on GitHub.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  minelink:
+    build: .
+    environment:
+      - SERVER_ADDRESS=${SERVER_ADDRESS}
+      - PROXY_PORT=${PROXY_PORT}
+      - BROADCAST_IP=${BROADCAST_IP}
+    ports:
+      - "${PROXY_PORT}:${PROXY_PORT}"


### PR DESCRIPTION
Add Docker support to the project.

* **Dockerfile**: Create a `Dockerfile` to build the Go application using `golang:1.20` as the base image, set the working directory to `/app`, copy the project files, build the Go application, and set the entrypoint.
* **docker-compose.yml**: Create a `docker-compose.yml` file to define the `minelink` service, use the `Dockerfile` to build the service, set environment variables for `SERVER_ADDRESS`, `PROXY_PORT`, and `BROADCAST_IP`, and map the proxy port to the host.
* **README.md**: Add instructions for building and running the application using Docker and Docker Compose, including steps for cloning the repository, building the Docker image, running the Docker container, creating a `.env` file, and starting the service using Docker Compose.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/waushop/minelink/pull/2?shareId=18d004e8-a135-44d0-9a66-ee33f57ec357).