### PR TITLE
Initialize Go module for the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,17 @@ To run the proxy, follow these steps:
    ```
    cd minelink
    ```
-3. Set the environment variables as needed:
+3. Initialize the Go module:
+   ```
+   go mod init minelink
+   ```
+4. Set the environment variables as needed:
    ```
    export SERVER_ADDRESS="your_server_address:19132"
    export PROXY_PORT="19133"
    export BROADCAST_IP="255.255.255.255:19132"
    ```
-4. Build and run the proxy:
+5. Build and run the proxy:
    ```
    go build -o minelink
    ./minelink


### PR DESCRIPTION
Update `README.md` to include instructions for initializing the Go module before building the project.

* Add a step to initialize the Go module by running `go mod init minelink` in the project directory.
* Adjust the numbering of subsequent steps accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/waushop/minelink/pull/3?shareId=097f32bb-a83c-45f7-94cd-1a988c9ffcd1).